### PR TITLE
Optional FD Compat, Fix Dedicated Server Event

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -114,7 +114,8 @@ dependencies {
     runtimeOnly fg.deobf("mezz.jei:jei-${project.mc_version}:${jei_version}")
 
     implementation fg.deobf("curse.maven:detail-armor-bar-forge-520755:3723059")
-    implementation fg.deobf("curse.maven:farmers-delight-398521:3834150")
+    compileOnly fg.deobf("curse.maven:farmers-delight-398521:3834150")
+    runtimeOnly fg.deobf("curse.maven:farmers-delight-398521:3834150")
 
     // For testing and showcasing with pretty shaders:
     runtimeOnly fg.deobf("curse.maven:oculus-581495:3821406")

--- a/src/main/java/me/gleep/oreganized/Oreganized.java
+++ b/src/main/java/me/gleep/oreganized/Oreganized.java
@@ -9,6 +9,7 @@ import com.redlimerl.detailab.api.render.TextureOffset;
 import me.gleep.oreganized.blocks.client.ShrapnelBombRenderer;
 import me.gleep.oreganized.capabilities.CapabilityHandler;
 import me.gleep.oreganized.client.OreganizedClient;
+import me.gleep.oreganized.compat.FarmersDelightCompat;
 import me.gleep.oreganized.data.OBlockTags;
 import me.gleep.oreganized.data.OItemTags;
 import me.gleep.oreganized.data.OSoundDefinitions;
@@ -75,6 +76,10 @@ public class Oreganized {
         bus.addListener(this::gatherData);
 
         MinecraftForge.EVENT_BUS.addListener(OreganizedFeatures::onBiomeLoadingEvent);
+
+        if (ModList.get().isLoaded("farmersdelight")) {
+            FarmersDelightCompat.init();
+        }
 
         DeferredRegister<?>[] registers = {
                 //OBlockEntities.BLOCK_ENTITIES,

--- a/src/main/java/me/gleep/oreganized/compat/FarmersDelightCompat.java
+++ b/src/main/java/me/gleep/oreganized/compat/FarmersDelightCompat.java
@@ -1,0 +1,15 @@
+package me.gleep.oreganized.compat;
+
+import me.gleep.oreganized.items.tiers.OreganizedTiers;
+import me.gleep.oreganized.registry.OItems;
+import net.minecraft.world.item.Item;
+import net.minecraftforge.registries.RegistryObject;
+import vectorwing.farmersdelight.FarmersDelight;
+import vectorwing.farmersdelight.common.item.KnifeItem;
+
+public class FarmersDelightCompat {
+    public static final RegistryObject<Item> ELECTRUM_KNIFE = OItems.ITEMS.register("electrum_knife",
+            () -> new KnifeItem(OreganizedTiers.ELECTRUM, 0.5F, -1.8F, (new Item.Properties()).tab(FarmersDelight.CREATIVE_TAB)));
+
+    public static void init() {}
+}

--- a/src/main/java/me/gleep/oreganized/events/ModEvents.java
+++ b/src/main/java/me/gleep/oreganized/events/ModEvents.java
@@ -20,8 +20,6 @@ import me.gleep.oreganized.registry.OTags;
 import me.gleep.oreganized.tools.STSBase;
 import me.gleep.oreganized.util.messages.UpdateClientEngravedBlocks;
 import net.minecraft.advancements.CriteriaTriggers;
-import net.minecraft.client.Camera;
-import net.minecraft.client.Minecraft;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -199,7 +197,7 @@ public class ModEvents {
             }
         }
 
-        IEngravedBlocks cap = Minecraft.getInstance().player.level.getCapability(CapabilityEngravedBlocks.ENGRAVED_BLOCKS_CAPABILITY).orElse(null);
+        IEngravedBlocks cap = level.getCapability(CapabilityEngravedBlocks.ENGRAVED_BLOCKS_CAPABILITY).orElse(null);
         if (cap.isEngraved(pos) && item.getItem() instanceof AxeItem) {
             event.getPlayer().swing(event.getHand());
             level.playSound(event.getPlayer(), pos, SoundEvents.AXE_SCRAPE, SoundSource.BLOCKS, 1.0F, 1.0F);

--- a/src/main/java/me/gleep/oreganized/registry/OItems.java
+++ b/src/main/java/me/gleep/oreganized/registry/OItems.java
@@ -8,12 +8,9 @@ import me.gleep.oreganized.items.tiers.OreganizedTiers;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.entity.EquipmentSlot;
 import net.minecraft.world.item.*;
-import net.minecraftforge.fml.ModList;
 import net.minecraftforge.registries.DeferredRegister;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.registries.RegistryObject;
-import vectorwing.farmersdelight.FarmersDelight;
-import vectorwing.farmersdelight.common.item.KnifeItem;
 
 import static me.gleep.oreganized.util.RegistryHandler.*;
 
@@ -83,8 +80,4 @@ public class OItems {
     public static final RegistryObject<Item> ELECTRUM_BOOTS = ITEMS.register("electrum_boots",
             () -> new ElectrumArmorItem(OreganizedArmorMaterials.ELECTRUM, EquipmentSlot.FEET)
     );
-
-    // Compatibility
-    public static final RegistryObject<Item> ELECTRUM_KNIFE = ITEMS.register("electrum_knife",
-            () -> new KnifeItem(OreganizedTiers.ELECTRUM, 0.5F, -1.8F, (new Item.Properties()).tab(ModList.get().isLoaded(FarmersDelight.MODID) ? FarmersDelight.CREATIVE_TAB : null)));
 }


### PR DESCRIPTION
- Just created a separate class with the Farmer's Delight addition and
  load that class when the Farmer's Delight is detected
- Remove reference to client Minecraft instance in ModEvents and just
  use the level from the event instead